### PR TITLE
Adds graphql-url atrtibute to manifold-plan-matrix

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -23,6 +23,7 @@ export namespace Components {
   interface ManifoldPlanMatrix {
     'baseUrl'?: string;
     'ctaText'?: string;
+    'graphqlUrl'?: string;
     'productLabel'?: string;
   }
   interface ManifoldThead {
@@ -77,6 +78,7 @@ declare namespace LocalJSX {
   interface ManifoldPlanMatrix {
     'baseUrl'?: string;
     'ctaText'?: string;
+    'graphqlUrl'?: string;
     'productLabel'?: string;
   }
   interface ManifoldThead {

--- a/src/components/manifold-plan-matrix/manifold-plan-matrix.tsx
+++ b/src/components/manifold-plan-matrix/manifold-plan-matrix.tsx
@@ -21,6 +21,8 @@ export class ManifoldPricing {
   @Prop() baseUrl?: string = '/signup';
   // CTA Text for buttons
   @Prop() ctaText?: string = 'Get Started';
+  // Graphql enpoint (TEMP)
+  @Prop() graphqlUrl?: string = GRAPHQL_ENDPOINT;
   // Product data
   @State() product?: ProductQuery['product'];
   // Plans data
@@ -33,7 +35,7 @@ export class ManifoldPricing {
   componentWillLoad() {
     const DEFAULT = 'ziggeo';
     const variables: ProductQueryVariables = { label: this.productLabel || DEFAULT, first: 50 };
-    fetch(GRAPHQL_ENDPOINT, {
+    fetch(this.graphqlUrl || GRAPHQL_ENDPOINT, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

## Reason for change

Add's the ability to specify the graphql url for demo purposes.

## Testing

add `graphql-url` in storybook or the index.html dev environment and test!
