### PR TITLE
Add CDN publishing for stable releases

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -11,7 +11,7 @@ jobs:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
       - run: npm install
       - run: 'echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,8 +11,50 @@ jobs:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
       - run: npm install
       - run: 'echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc'
       - run: 'npm publish --tag latest'
+  cdn:
+    env:
+      BUCKET: manifold-js
+      GOOGLE_APPLICATION_CREDENTIALS: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
+      PACKAGE: '@manifoldco/component-plan-matrix' # package name
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [13.x]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+      - uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+        with:
+          service_account_key: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
+          export_default_credentials: true
+      - run: npm install
+      - run: npm run build
+      # Copy all files for versioned release (/package@version/)
+      - run:
+          gsutil -m cp ${GITHUB_WORKSPACE}/LICENSE
+          gs://${BUCKET}/${PACKAGE}@${GITHUB_REF#refs/tags/v}/LICENSE
+      - run:
+          gsutil -m cp ${GITHUB_WORKSPACE}/README.md
+          gs://${BUCKET}/${PACKAGE}@${GITHUB_REF#refs/tags/v}/README.md
+      - run:
+          gsutil -m cp ${GITHUB_WORKSPACE}/package.json
+          gs://${BUCKET}/${PACKAGE}@${GITHUB_REF#refs/tags/v}/package.json
+      - run:
+          gsutil -m cp -r ${GITHUB_WORKSPACE}/dist
+          gs://${BUCKET}/${PACKAGE}@${GITHUB_REF#refs/tags/v}
+      - run:
+          gsutil -m cp -r ${GITHUB_WORKSPACE}/loader
+          gs://${BUCKET}/${PACKAGE}@${GITHUB_REF#refs/tags/v}
+      # Copy all files for latest stable release (/package/)
+      - run: gsutil -m cp ${GITHUB_WORKSPACE}/LICENSE gs://${BUCKET}/${PACKAGE}/LICENSE # overwrite these files
+      - run: gsutil -m cp ${GITHUB_WORKSPACE}/README.md gs://${BUCKET}/${PACKAGE}/README.md
+      - run: gsutil -m cp ${GITHUB_WORKSPACE}/package.json gs://${BUCKET}/${PACKAGE}/package.json
+      - run: gsutil -m rm -rf gs://${BUCKET}/${PACKAGE}/dist # remove /dist and /loader contents so no cruft remains from previous version
+      - run: gsutil -m rm -rf gs://${BUCKET}/${PACKAGE}/loader
+      - run: gsutil -m cp -r ${GITHUB_WORKSPACE}/dist gs://${BUCKET}/${PACKAGE} # copy /dist and /loader folders
+      - run: gsutil -m cp -r ${GITHUB_WORKSPACE}/loader gs://${BUCKET}/${PACKAGE}


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

## Reason for change

Followup to previous PR. Adds CDN publishing for stable releases:

- https://js.cdn.manifold.co/@manifoldco/component-plan-matrix/
- https://js.cdn.manifold.co/@manifoldco/component-plan-matrix@{version}/

## Testing

You can see here it published the latest versions:

![Screen Shot 2020-03-02 at 08 15 08](https://user-images.githubusercontent.com/1369770/75689162-f5933280-5c5d-11ea-98de-5d925a2ee8a3.png)

Note that **it’s OK the release job failed in GitHub Actions.** It failed because npm won’t let us re-publish that version to npm. But if you check the CDN job, it worked. Anyway a CI failure is expected here.
