### PR TITLE
Clean package.json before publishing to prevent weirdness

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
       - run: npm install
-      - run: npm run build
+      - run: make package
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/Makefile
+++ b/Makefile
@@ -10,3 +10,4 @@ package:
 	cp LICENSE pkg/.
 	cp README.md pkg/.
 	cp package.json pkg/.
+	npm run clean-package-json

--- a/package.json
+++ b/package.json
@@ -12,13 +12,10 @@
   "collection:main": "dist/collection/index.js",
   "unpkg": "dist/manifold-plan-matrix/manifold-plan-matrix.js",
   "license": "MIT",
-  "files": [
-    "dist/",
-    "loader/"
-  ],
   "scripts": {
     "build": "stencil build",
     "build:watch": "stencil build --watch",
+    "clean-package-json": "node scripts/clean-package-json",
     "dev": "npm run build:watch & rm -rf dist loader && wait-on loader/index.cjs.js && npm run storybook",
     "happo": "npm run build && npm run generate:gql && happo run",
     "generate": "stencil generate",

--- a/scripts/clean-package-json.js
+++ b/scripts/clean-package-json.js
@@ -1,0 +1,18 @@
+const fs = require('fs');
+const path = require('path');
+
+const PACKAGE_JSON_LOCATION = path.resolve(__dirname, '..', 'pkg', 'package.json');
+
+if (!fs.existsSync(PACKAGE_JSON_LOCATION)) {
+  console.error('pkg/package.json not found. Did you forget to build?');
+}
+
+// read file
+const packageJson = JSON.parse(fs.readFileSync(PACKAGE_JSON_LOCATION, 'utf8'));
+
+// clean file
+delete packageJson.files;
+delete packageJson.scripts;
+
+// save file
+fs.writeFileSync(PACKAGE_JSON_LOCATION, JSON.stringify(packageJson, undefined, 2), 'utf8');


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

## Reason for change

See thread [here](https://manifoldco.slack.com/archives/C71TY115F/p1584023530205100) but in short: cleaning `package.json` is a good practice that I learned from shipping a broken UI build yesterday 🙈, because when packages try and install your package it’ll also try to run any `scripts` you may or may not want it to.

## Testing

None! CI should pass
