### PR TITLE
Use gateway url prop

### DIFF
--- a/src/components/manifold-plan-matrix/manifold-plan-matrix.tsx
+++ b/src/components/manifold-plan-matrix/manifold-plan-matrix.tsx
@@ -179,7 +179,7 @@ export class ManifoldPricing {
       }, 150);
 
       // fetch plan cost for this configurable plan
-      fetchPlanCost({ planID, selection, url: GATEWAY_ENDPOINT }).then(cost => {
+      fetchPlanCost({ planID, selection, url: this.gatewayUrl || GATEWAY_ENDPOINT }).then(cost => {
         if (typeof cost === 'number') {
           clearTimeout(flickerStopper);
           this.planCosts = merge(this.planCosts, { [planID]: cost });


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

## Reason for change

Gateway URL prop was being set but ignored in the call to plan cost API.

Pretty sure this requires further work once mui-core has a restFetch function, but it's a fix for now.

## Testing

This should be safe to just test on stage.
