### PR TITLE
Revert "Use micro cost util for feature options"

### DIFF
--- a/src/components/manifold-plan-matrix/manifold-plan-matrix.tsx
+++ b/src/components/manifold-plan-matrix/manifold-plan-matrix.tsx
@@ -4,7 +4,7 @@ import merge from 'deepmerge';
 import { Connection } from '@manifoldco/mui-core-types/types/v0';
 
 import { ProductQueryVariables, ProductQuery, PlanFeatureType } from '../../types/graphql';
-import { microCostToDollars } from '../../utils/cost';
+import { toUSD } from '../../utils/cost';
 import { defaultFeatureValue, fetchPlanCost } from '../../utils/feature';
 import logger, { loadMark } from '../../utils/logger';
 import analytics from '../../packages/analytics';
@@ -251,7 +251,7 @@ export class ManifoldPricing {
                 {(feature.featureOptions || []).map(option => (
                   <option value={option.value}>
                     <span>{option.displayName}</span>
-                    <span> ({microCostToDollars(option.cost)})</span>
+                    <span> ({toUSD(option.cost)})</span>
                   </option>
                 ))}
               </select>


### PR DESCRIPTION
This reverts commit fe9f1c49368285353c89e15bc302b6715ebaf255.