### PR TITLE
Temporarily master Happo build fix

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -9,7 +9,7 @@ jobs:
   vrt:
     env:
       CURRENT_SHA: ${{ github.sha }}
-      PREVIOUS_SHA: ${{ github.event.before }}
+      PREVIOUS_SHA: ${{ github.sha }}
       CHANGE_URL: ${{ github.event.compare }}
       HAPPO_API_KEY: ${{ secrets.HAPPO_API_KEY }}
       HAPPO_API_SECRET: ${{ secrets.HAPPO_API_SECRET }}


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

## Reason for change

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

As long as the master Happo build is broken, using a `PREVIOUS_SHA` that points to a failed build will fail. For now, use the same commit for `CURRENT_SHA` and `PREVIOUS_SHA`, until the master build is working.

## Testing

<!-- For someone unfamiliar with the issue, how should this be tested? -->

## Checklist

- [ ] [CHANGELOG](./CHANGELOG.md) updated
