### PR TITLE
Improve exclusive tiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Improved pricing tier display for metered features
+
+### Fixed
+
+- Fixed pricing tier overlapping numbers (e.g. for 0–100, 100—∞, `100` shouldn’t appear twice)
+
 ## 0.0.1 - 2020-03-18
 
 ### Added
 
 - Initial release
+
+[unreleased]: https://github.com/manifoldco/manifold-plan-table/compare/v0.0.1...HEAD

--- a/src/components/manifold-plan-table/manifold-plan-table.css
+++ b/src/components/manifold-plan-table/manifold-plan-table.css
@@ -329,9 +329,7 @@
 
 .mp--metered__header {
   color: hsl(var(--empty-color));
-  display: grid;
   font-size: 11px;
-  grid-template-columns: 1fr 1fr;
 }
 
 .mp--metered__header-text {
@@ -344,20 +342,29 @@
 }
 
 .mp--metered__cost-tiers {
-  border-top: var(--table-metered-border);
   color: var(--c-gray-darker);
-  display: grid;
   font-size: 14px;
-  grid-template-columns: 1fr 1fr;
   line-height: 1.2;
 }
 
-.mp--metered__cost-tiers__text {
-  margin: 6px 0;
+.mp--metered__cost-tiers__range {
+  border-top: var(--table-metered-border);
+  white-space: nowrap;
+  padding: 0.375rem 0;
 }
 
-.mp--metered__cost-tiers__last {
-  text-align: right;
+.mp--metered__cost-tiers__cost {
+  border-top: var(--table-metered-border);
+  padding: 0.375rem 0;
+}
+
+.mp--metered__cost-tiers[data-multitiered] {
+  display: grid;
+  grid-template-columns: min-content auto;
+
+  & .mp--metered__cost-tiers__cost {
+    padding-left: 0.75rem;
+  }
 }
 
 /**

--- a/src/index.html
+++ b/src/index.html
@@ -29,6 +29,14 @@
   </head>
   <body>
     <manifold-init env="stage" client-id="123456"></manifold-init>
+    <!-- blitline: 234htwpkzvg1vuyez6uybfhv8rjb2 -->
+    <!-- cloudcube: 234vpcvg8k7dty17j7wmazfpdbrag -->
+    <!-- custom image: 234q7ufpnwffnw63ktp1bzeqzxzdy -->
+    <!-- jawsdb-mysql: 234w1jyaum5j0aqe3g3bmbqjgf20p -->
+    <!-- prefab: 234j199gnaggg2qj6fvey2m3gw1nc -->
+    <!-- till: 234jqxdqzjmcr5vu8uhc8dacx3xww -->
+    <!-- zerosix: 234nbp17j5zrvb2ym49647kgtyv2a -->
+    <!-- ziggeo: 234yycr3mf5f2hrw045vuxeatnd50 -->
     <manifold-plan-table
       product-id="234j94djrwxapnnbyqbjtg75g111j"
       client-id="123456"

--- a/src/utils/cost.spec.ts
+++ b/src/utils/cost.spec.ts
@@ -1,4 +1,4 @@
-import { displayTierCost, displayLimit } from './cost';
+import { displayTierCost } from './cost';
 
 describe('displayTierCost', () => {
   it('very cheap', () => {
@@ -19,19 +19,5 @@ describe('displayTierCost', () => {
 
   it('seconds', () => {
     expect(displayTierCost(360000, 'second')).toBe('$1.30 / hour');
-  });
-});
-
-describe('displayLimit', () => {
-  it('-1', () => {
-    expect(displayLimit(-1, 'email')).toBe('∞');
-  });
-
-  it('200', () => {
-    expect(displayLimit(200, 'email')).toBe('200');
-  });
-
-  it('seconds', () => {
-    expect(displayLimit(3600, 'second')).toBe('1');
   });
 });

--- a/src/utils/text.ts
+++ b/src/utils/text.ts
@@ -21,3 +21,10 @@ export function pluralize(word: string) {
     .replace(/s$/i, 'se')
     .concat('s');
 }
+
+/**
+ * Strip off trailing “s” (adjust as-needed)
+ */
+export function singularize(word: string) {
+  return word.replace(/s$/, '');
+}


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

## Reason for change

Fixes bug where 2 cost tier would show the same #, so it wasn’t clear if the tiers were inclusive or exclusive.

Also changes the display a bit:

**Single tier**

![Screen Shot 2020-03-27 at 11 03 15](https://user-images.githubusercontent.com/1369770/77783086-de0d5680-701d-11ea-8818-37cbb366d637.png)


**Multi-tiered: adds in 2nd column**

![Screen Shot 2020-03-27 at 11 26 39](https://user-images.githubusercontent.com/1369770/77783069-d8177580-701d-11ea-8794-913b6638687d.png)



## Testing

<!-- For someone unfamiliar with the issue, how should this be tested? -->

## Checklist

- [x] [CHANGELOG](./CHANGELOG.md) updated
