### PR TITLE
Use anchor's href as CTA navigation URL

### DIFF
--- a/src/components/manifold-plan-table/manifold-plan-table.tsx
+++ b/src/components/manifold-plan-table/manifold-plan-table.tsx
@@ -215,7 +215,7 @@ export class ManifoldPlanTable {
     return `${this.baseUrl}?${search.toString()}`;
   }
 
-  handleCtaClick(e: MouseEvent, planId: string, destination = '') {
+  handleCtaClick = (planId: string) => (e: MouseEvent) => {
     e.preventDefault();
 
     this.connection.analytics
@@ -228,9 +228,10 @@ export class ManifoldPlanTable {
         },
       })
       .then(() => {
-        window.location.href = destination;
+        const anchor = e.srcElement as HTMLAnchorElement;
+        window.location.href = anchor.href;
       });
-  }
+  };
 
   setFeature({
     planID,
@@ -448,7 +449,7 @@ export class ManifoldPlanTable {
                 class="ManifoldPlanTable__Button"
                 id={`manifold-cta-plan-${plan.id}`}
                 href={this.ctaHref(plan.id)}
-                onClick={(e) => this.handleCtaClick(e, plan.id, this.baseUrl)}
+                onClick={this.handleCtaClick(plan.id)}
               >
                 {this.ctaText}
               </a>


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

## Reason for change

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

We were navigating to the base URL on CTA click, and that was causing us to lose the plan ID and configurable feature data that should have been in the query params.

## Testing

<!-- For someone unfamiliar with the issue, how should this be tested? -->

## Checklist

- [ ] [CHANGELOG](./CHANGELOG.md) updated
