### PR TITLE
Fix select component alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Better namespaced CSS with BEM `.mp-*` ➡️ `.ManifoldPlanTable__*`
 - Now styles auto-update with the [Manifold Design System](https://github.com/manifoldco/mercury)
 
+### Fixed
+
+- Fixes `<select>` element alignment in Chrome
+
 ## [0.0.16] - 2020-03-30
 
 ### Changed
@@ -29,4 +33,5 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Initial release
 
+[0.2.0]: https://github.com/manifoldco/manifold-plan-table/compare/v0.0.16...v0.2.0
 [0.0.16]: https://github.com/manifoldco/manifold-plan-table/compare/v0.0.1...v0.0.16

--- a/src/styles/elements/_select.scss
+++ b/src/styles/elements/_select.scss
@@ -8,6 +8,7 @@ $name: '' !default;
 $transition: 150ms linear;
 
 .#{$name}__Select {
+  align-items: center;
   background: mercury.$color-white;
   border-radius: 3px;
   color: inherit;


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

## Reason for change

Fixes `<select>` in Chromium.

**Before**
![Screen Shot 2020-04-07 at 08 19 09](https://user-images.githubusercontent.com/1369770/78680379-a36eae00-78a8-11ea-997c-1e549c625e77.png)


**After**

![Screen Shot 2020-04-07 at 08 19 14](https://user-images.githubusercontent.com/1369770/78680392-a7023500-78a8-11ea-9231-d8d74d090cf3.png)


<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

## Testing

<!-- For someone unfamiliar with the issue, how should this be tested? -->

## Checklist

- [x] [CHANGELOG](./CHANGELOG.md) updated
