### PR TITLE
Add update, init events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Adds `click`, `update`, `init` custom events
+
 ## [0.3.0] - 2020-04-17
 
 ### Changed
 
 - Firing a CTAClick event when CTA is clicked
-- Add version attribute to get latest product and plan versions (currently only works with "latest" value).
+- Add version attribute to get latest product and plan versions (currently only works with "latest"
+  value).
 
 ## [0.2.0] - 2020-04-01
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,35 @@ Options are passed to the component in the form of HTML Attributes:
 | `client-id`  |    Y     | Your Account identifier (this helps us associate analytics to your account)                                     | `<manifold-plan-table client-id="284ablb7scfm8oxwz9wrxpt2q0jii">`  |
 | `base-url`   |          | The URL the buttons link to (plan ID & user selection will be appended to the end of the URL in a query string) | `<manifold-plan-table base-url="/checkout">`                       |
 | `cta-text`   |          | Change the ”Getting Started” default text.                                                                      | `<manifold-plan-table cta-text="Buy Now!">`                        |
-| `version`   |          | The version of your product (omit for latest published product). Use `version="latest"` for the latest draft.                                                                       | `<manifold-plan-table version="1">`                        |
+| `version`    |          | The version of your product (omit for latest published product). Use `version="latest"` for the latest draft.   | `<manifold-plan-table version="1">`                                |
+
+## Events
+
+This component emits [Custom JavaScript Events][custom-events] at key interaction points.
+
+### Setup
+
+To begin listening for events, add a listener like so (you’ll want to make sure that this component
+exists in the DOM):
+
+```js
+// your custom listener function
+function myFunc(evt) {
+  console.log(evt);
+}
+
+document.querySelector('manifold-plan-table').addEventListener('ctaClick', myFunc); // do something on CTA clicks
+document.querySelector('manifold-plan-table').addEventListener('init', myFunc); // do something on initial load
+document.querySelector('manifold-plan-table').addEventListener('update', myFunc); // do something on updates
+```
+
+### All Events
+
+| Event Name | Trigger                                                                                                               | Returns                                      |
+| :--------- | :-------------------------------------------------------------------------------------------------------------------- | :------------------------------------------- |
+| `ctaClick` | Fires when a user clicks the CTA                                                                                      | `planID`, `planDisplayName`, `userSelection` |
+| `init`     | Fires once when the component has loaded (broadcasts default options for all plans)                                   | `defaultSelections`                          |
+| `update`   | Fires when a user selects a feature option (if you don’t have user-selectable features, you probably don’t need this) | `planID`, `planDisplayName`, `userSelection` |
 
 ## TypeScript + JSX
 
@@ -117,6 +145,8 @@ features like refs:
 // Property 'fakeproperty' does not exist on type …
 ```
 
+[custom-events]:
+  https://developer.mozilla.org/en-US/docs/Web/Guide/Events/Creating_and_triggering_events
 [manifold-init]: https://github.com/manifoldco/manifold-init
 [stencil-framework]: https://stenciljs.com/docs/overview
 [stencil]: https://stenciljs.com/docs/introduction

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -34,7 +34,9 @@ declare namespace LocalJSX {
         "ctaText"?: string;
         "env"?: "stage" | "local" | "prod";
         "gatewayUrl"?: string;
-        "onCTAClick"?: (event: CustomEvent<any>) => void;
+        "onCtaClick"?: (event: CustomEvent<PlanTableEvent>) => void;
+        "onInit"?: (event: CustomEvent<PlanTableInit>) => void;
+        "onUpdate"?: (event: CustomEvent<PlanTableEvent>) => void;
         "productId"?: string;
         "version"?: string;
     }

--- a/src/components/manifold-plan-table/manifold-plan-table.spec.ts
+++ b/src/components/manifold-plan-table/manifold-plan-table.spec.ts
@@ -26,8 +26,9 @@ async function setup(props: Props) {
 
   const component = page.doc.createElement('manifold-plan-table');
 
-  component.productId = props.productId;
+  component.baseUrl = props.baseUrl;
   component.clientId = props.clientId;
+  component.productId = props.productId;
   component.version = props.version;
 
   const root = page.root as HTMLDivElement;
@@ -92,7 +93,11 @@ describe(ManifoldPlanTable.name, () => {
 
       const PLAN_ID = '235abe2ba8b39e941u2h70ayw5m9j';
       const PLAN_ID_CUSTOM = '235exy25wvzpxj52p87bh87gbnj4y'; // test custom to test features
-      const { page } = await setup({ productId: 'product-id', clientId: 'client-id' });
+      const { page } = await setup({
+        baseUrl: '/signup',
+        productId: 'product-id',
+        clientId: 'client-id',
+      });
       const cta = page.root && page.root.querySelector(`[id="manifold-cta-plan-${PLAN_ID}"]`);
       const ctaCustom =
         page.root && page.root.querySelector(`[id="manifold-cta-plan-${PLAN_ID_CUSTOM}"]`);

--- a/src/styles/elements/_button.scss
+++ b/src/styles/elements/_button.scss
@@ -8,10 +8,13 @@ $name: '' !default;
 .#{$name}__Button {
   @include mercury.Manifold__Typography__Body;
 
+  appearance: none;
   background: mercury.$color-blue;
+  border: none;
   border-radius: 4px;
   box-sizing: border-box;
   color: mercury.$color-white;
+  cursor: pointer;
   flex: 1;
   font-style: normal;
   font-weight: 500;


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

## Reason for change

When users implement the plan table, they might not want to use an `<a>` tag for the button to redirect the URL. They may want to implement their own custom behavior in JS.

For that, we need to give them events to listen to, similar to how `<manifold-plan-selector>` works.

Here’s a video of it emitting events (analytics shown at the end):

![2020-04-24 15-05-17 2020-04-24 15_06_30](https://user-images.githubusercontent.com/1369770/80257050-4f502180-863d-11ea-9663-7584ebcc9697.gif)

## Testing

Start up the local server with `npm start`, then run in your console:

```js
pt = document.querySelector('manifold-plan-table');
pt.addEventListener('ctaClick', evt => console.log('ctaClick, evt.detail));
pt.addEventListener('update', evt => console.log('update, evt.detail));
```

## Checklist

- [x] [CHANGELOG](./CHANGELOG.md) updated
