### PR TITLE
Change each plan column into a proper form

### DIFF
--- a/src/components/manifold-plan-table/manifold-plan-table.spec.ts
+++ b/src/components/manifold-plan-table/manifold-plan-table.spec.ts
@@ -86,24 +86,6 @@ describe(ManifoldPlanTable.name, () => {
       expect(options.body).toContain('"latest":false');
     });
 
-    it('cta URL', async () => {
-      // mock jawsDB endpoint
-      fetchMock.mock(GRAPHQL_ENDPOINT, mockJawsDB);
-
-      const PLAN_ID = '235abe2ba8b39e941u2h70ayw5m9j';
-      const PLAN_ID_CUSTOM = '235exy25wvzpxj52p87bh87gbnj4y'; // test custom to test features
-      const { page } = await setup({ productId: 'product-id', clientId: 'client-id' });
-      const cta = page.root && page.root.querySelector(`[id="manifold-cta-plan-${PLAN_ID}"]`);
-      const ctaCustom =
-        page.root && page.root.querySelector(`[id="manifold-cta-plan-${PLAN_ID_CUSTOM}"]`);
-
-      expect(cta.getAttribute('href')).toBe(`/signup?planId=${PLAN_ID}`);
-      // note: this test shouldn’t flake, but if it does, find some way to ensure custom features are tested
-      expect(ctaCustom.getAttribute('href')).toBe(
-        `/signup?planId=${PLAN_ID_CUSTOM}&backups=1&instance_class=db.t2.micro&redundancy=false&storage=5`
-      );
-    });
-
     describe('analytics', () => {
       beforeEach(() => {
         fetchMock.mock(GRAPHQL_ENDPOINT, mockLogDna);

--- a/src/components/manifold-plan-table/manifold-plan-table.spec.ts
+++ b/src/components/manifold-plan-table/manifold-plan-table.spec.ts
@@ -100,15 +100,9 @@ describe(ManifoldPlanTable.name, () => {
           clientId,
         });
 
-        const cta =
-          page.root &&
-          (page.root.querySelector<HTMLAnchorElement>(`[data-testid="cta"]`) as HTMLAnchorElement);
+        const forms = page.root.querySelector<HTMLFormElement>('form');
 
-        if (!cta) {
-          throw new Error('cta not found in document');
-        }
-
-        cta.click();
+        forms.dispatchEvent(new Event('submit'));
 
         const [[, analyticsRes]] = fetchMock
           .calls()

--- a/src/components/manifold-plan-table/manifold-plan-table.tsx
+++ b/src/components/manifold-plan-table/manifold-plan-table.tsx
@@ -408,7 +408,7 @@ export class ManifoldPlanTable {
               onSubmit={this.onSubmit(plan.id)}
               style={{ display: 'contents' }}
             >
-              <input hidden name="planId" value={plan.id} />
+              <input type="hidden" name="planId" value={plan.id} />
               {[
                 Object.values(this.planFeatures[plan.id]).map((feature) => {
                   // fixed feature

--- a/src/components/manifold-plan-table/manifold-plan-table.tsx
+++ b/src/components/manifold-plan-table/manifold-plan-table.tsx
@@ -406,7 +406,7 @@ export class ManifoldPlanTable {
             <form
               action={this.baseUrl}
               onSubmit={this.onSubmit(plan.id)}
-              style={{ display: 'contents' }}
+              class="ManifoldPlanTable__Plan__Form"
             >
               <input type="hidden" name="planId" value={plan.id} />
               {[

--- a/src/components/manifold-plan-table/manifold-plan-table.tsx
+++ b/src/components/manifold-plan-table/manifold-plan-table.tsx
@@ -205,42 +205,6 @@ export class ManifoldPlanTable {
     });
   }
 
-  ctaHref(planID: string) {
-    if (!this.baseUrl || this.baseUrl === '#') {
-      return this.baseUrl;
-    }
-
-    const search = new URLSearchParams();
-    // set plan ID
-    search.set('planId', planID);
-
-    // set configurable feature selection (or skip, if no configurable features);
-    Object.entries(this.userSelection[planID] || {}).forEach(([key, val]) => {
-      search.set(key, `${val}`);
-    });
-
-    return `${this.baseUrl}?${search.toString()}`;
-  }
-
-  handleCtaClick = (planId: string) => (e: MouseEvent) => {
-    e.preventDefault();
-    this.CTAClick.emit({ id: `manifold-cta-plan-${planId}` });
-
-    this.connection.analytics
-      .track({
-        description: 'Track pricing matrix cta clicks',
-        name: 'click',
-        type: 'component-analytics',
-        properties: {
-          planId,
-        },
-      })
-      .finally(() => {
-        const anchor = e.srcElement as HTMLAnchorElement;
-        window.location.href = anchor.href;
-      });
-  };
-
   setFeature({
     planID,
     featureLabel,
@@ -444,6 +408,7 @@ export class ManifoldPlanTable {
               onSubmit={this.onSubmit(plan.id)}
               style={{ display: 'contents' }}
             >
+              <input hidden name="planId" value={plan.id} />
               {[
                 Object.values(this.planFeatures[plan.id]).map((feature) => {
                   // fixed feature

--- a/src/index.html
+++ b/src/index.html
@@ -31,7 +31,7 @@
     </style>
   </head>
   <body>
-    <manifold-init client-id="123456"></manifold-init>
+    <manifold-init env="stage" client-id="123456"></manifold-init>
     <!-- blitline: 234htwpkzvg1vuyez6uybfhv8rjb2 -->
     <!-- cloudcube: 234vpcvg8k7dty17j7wmazfpdbrag -->
     <!-- custom image: 234q7ufpnwffnw63ktp1bzeqzxzdy -->
@@ -40,9 +40,6 @@
     <!-- till: 234jqxdqzjmcr5vu8uhc8dacx3xww -->
     <!-- zerosix: 234nbp17j5zrvb2ym49647kgtyv2a -->
     <!-- ziggeo: 234yycr3mf5f2hrw045vuxeatnd50 -->
-    <manifold-plan-table
-      product-id="234yycr3mf5f2hrw045vuxeatnd50"
-      client-id="123456"
-    ></manifold-plan-table>
+    <manifold-plan-table product-id="234j94djrwxapnnbyqbjtg75g111j"></manifold-plan-table>
   </body>
 </html>

--- a/src/styles/elements/_plan.scss
+++ b/src/styles/elements/_plan.scss
@@ -25,4 +25,8 @@ $name: '' !default;
     font-size: 14px;
     line-height: 1.2;
   }
+
+  &__Form {
+    display: contents;
+  }
 }


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

## Reason for change

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

This prevents users from using the _Get Started_ button if any of the configurable feature values are invalid.

For example, if a numeric feature has an increment of 10, and a user specifies a number that's between increments, the user should see a validation error and should be unable to proceed without fixing it.

I implemented this with the following changes:

1. Change each column into a proper form
1. Add a `name` attribute to each configurable feature input such that it matches the feature label
1. Add a hidden `planId` input in the form

This _Uses The Platform_ :tm: so that: 

1. A form submission will not occur if any fields are invalid
1. A validation error will be presented to the user for any invalid field
1. If the form is valid, we'll raise a custom event and perform analytics tracking
1. If they supplied a URL, the event's default behavior will proceed, so the form will submit to the supplied URL via GET, and data from the form inputs will be added to the query string automatically

## Testing

<!-- For someone unfamiliar with the issue, how should this be tested? -->

You'll need a product with configurable features to test with. This PR changes the environment and product ID so that the product data will include configurable features.

For this product ID, the increment for the _Jus Ensache_ feature is 10, but the user has entered 55 and tried to submit the form. Instead of submitting, a validation message is displayed.

Now try submitting a valid form. A page transition should occur, and the new URL in the address bar should contain the planID and configurable feature selections that you'd chosen, e.g. http://localhost:3333/signup?planId=235e9tww1qvd3pkyn2j4x7937u3e4&sandwich=free&juice=1

## Checklist

- [ ] [CHANGELOG](./CHANGELOG.md) updated
