### PR TITLE
Add styling for disabled button

### DIFF
--- a/src/styles/elements/_button.scss
+++ b/src/styles/elements/_button.scss
@@ -30,4 +30,10 @@ $name: '' !default;
   &:hover {
     background: rgba(mercury.$color-blue, 0.85);
   }
+
+  &:disabled {
+    color: mercury.$color-gray;
+    background: mercury.$color-white;
+    border: 1px solid mercury.$color-gray;
+  }
 }


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

## Reason for change

* Update styling for `disabled` button status
<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

## Testing

Manually add a "disabled" property to a button in Storybook to see how it looks
<!-- For someone unfamiliar with the issue, how should this be tested? -->

## Checklist

- [ ] [CHANGELOG](./CHANGELOG.md) updated
